### PR TITLE
fix(package-json): specify types inside "exports"

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "require": "./lib/index.js",
-      "import": "./es/index.mjs"
+      "import": "./es/index.mjs",
+      "types": "./lib/index.d.ts"
     }
   },
   "sideEffects": false,
@@ -32,7 +33,7 @@
     "prettier": "^2.2.1",
     "ts-jest": "^27.0.5",
     "tsukuru": "^0.7.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.6.0"
   },
   "files": [
     "LICENSE",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "types": "lib",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "require": "./lib/index.js",
-      "import": "./es/index.mjs",
-      "types": "./lib/index.d.ts"
+      "import": "./es/index.mjs"
     }
   },
   "sideEffects": false,


### PR DESCRIPTION
When TypeScript uses `exports` field in package.json, the top-level `types` is ignored (as well as `main`). Each package has to specify `types` inside `exports` for TypeScript to correctly determine the path of types file